### PR TITLE
fix for cast_data.target text while casting

### DIFF
--- a/Modules/LuaTexts/LuaTexts.lua
+++ b/Modules/LuaTexts/LuaTexts.lua
@@ -818,11 +818,12 @@ local function update_text(font_string, event)
 	font_string:SetWordWrap(not not PitBull4_LuaTexts.word_wrap)
 end
 
-local next_spell, next_target
+local next_spell, next_target, next_cast_id
 function PitBull4_LuaTexts:UNIT_SPELLCAST_SENT(event, unit, target, cast_id, spell_id)
 	if unit ~= "player" then return end
 
 	next_spell = spell_id
+	next_cast_id = cast_id
 	next_target = target ~= "" and target or nil
 
 	self:OnSpellEvent(event, unit, cast_id, spell_id)
@@ -879,7 +880,7 @@ local function update_cast_data(event, unit, event_cast_id, event_spell_id)
 		elseif event then
 			data.delay = 0
 		end
-		if guid == player_guid and spell_id == next_spell then
+		if guid == player_guid and (spell_id == next_spell or cast_id == next_cast_id) then
 			data.target = next_target
 		end
 		data.casting = not channeling


### PR DESCRIPTION
For the BCC client, the `CastData(unit).target` LuaText was broken because it was never going into the `if` statement to set it. `UnitCastingInfo` isn't returning `spell_id` anymore ([this line](https://github.com/nebularg/PitBull4/blob/ba7b6f371e7e650aeceb4139d448c6c09cc2e8d8/Modules/LuaTexts/LuaTexts.lua#L865)). Even by following the bcc API signature [here ](https://wowpedia.fandom.com/wiki/API_UnitCastingInfo), the supposed `spell_id` field (8th field, right after `cast_id`), is `nil`.

Still broken for channeling since there's no cast id associated for channeled spells.

Haven't tested on the classic client, but the old spell id checks are still in place so it should be compatible.